### PR TITLE
Add JOOQ_DRIVER_CLASS_NAME for explicit driver selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres poorly to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `JOOQ_DRIVER_CLASS_NAME` parameter. Running multiple jdbc drivers can cause issues
+  if an explicit driver class is not defied.
 
 ## [0.4.3] - 2019-12-27
 ### Changed

--- a/easyconfig-jooq/src/main/java/fi/jubic/easyconfig/jooq/JooqConfiguration.java
+++ b/easyconfig-jooq/src/main/java/fi/jubic/easyconfig/jooq/JooqConfiguration.java
@@ -33,7 +33,14 @@ public class JooqConfiguration implements SqlDatabaseConfig {
             @EasyConfigProperty("JOOQ_PASSWORD") String password,
             @EasyConfigProperty("JOOQ_") JooqSettings jooqSettings,
             @EasyConfigProperty("JOOQ_DIALECT") String dialect,
-            @EasyConfigProperty(value = "JOOQ_POOL_SIZE", defaultValue = "-1") int poolSize
+            @EasyConfigProperty(
+                    value = "JOOQ_DRIVER_CLASS_NAME",
+                    defaultValue = ""
+            ) String driverClassName,
+            @EasyConfigProperty(
+                    value = "JOOQ_POOL_SIZE",
+                    defaultValue = "-1"
+            ) int poolSize
     ) {
         ConnectionFingerprint fingerprint = new ConnectionFingerprint(
                 url,
@@ -54,6 +61,10 @@ public class JooqConfiguration implements SqlDatabaseConfig {
         this.dataSource.setJdbcUrl(url);
         this.dataSource.setUsername(user);
         this.dataSource.setPassword(password);
+
+        if (!driverClassName.isEmpty()) {
+            this.dataSource.setDriverClassName(driverClassName);
+        }
 
         if (poolSize > 0) {
             this.dataSource.setMaximumPoolSize(poolSize);


### PR DESCRIPTION
Running multiple jdbc drivers can cause issues if an explicit driver
class is not defined.